### PR TITLE
Add Task for Sonatype Publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
             ${{ runner.os }}-m2-
 
       - name: Publish to Maven Local
-        run: ./gradlew build publishAllPublicationsToMavenLocalRepository
+        run: ./gradlew build publishToMavenLocal
 
       - name: Run tests
         env:

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ group = 'org.octopusden.octopus'
 description "License gradle plugin"
 
 repositories {
-    mavenLocal()
     mavenCentral()
     gradlePluginPortal()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,15 @@ plugins {
     id 'org.octopusden.octopus-release-management'
     id 'groovy'
     id 'java-gradle-plugin'
+    id 'io.github.gradle-nexus.publish-plugin'
+    id 'signing'
 }
 
 group = 'org.octopusden.octopus'
 description "License gradle plugin"
 
 repositories {
+    mavenLocal()
     mavenCentral()
     gradlePluginPortal()
 }
@@ -47,15 +50,63 @@ dependencies {
 
 apply plugin: 'maven-publish'
 
+nexusPublishing {
+    repositories {
+        sonatype {
+            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            username.set(System.getenv("MAVEN_USERNAME"))
+            password.set(System.getenv("MAVEN_PASSWORD"))
+        }
+    }
+}
+
 publishing {
     publications {
         mavenJava(MavenPublication) {
-            artifactId 'license-gradle-plugin'
+            artifactId = 'license-gradle-plugin'
             from components.java
+
+            pom {
+                name = 'Octopus License Gradle Plugin'
+                description = 'A plugin for license management in Gradle projects.'
+                url = 'https://github.com/octopusden/octopus-license-gradle-plugin.git'
+                licenses {
+                    license {
+                        name = 'The Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'octopus'
+                        name = 'Octopus Team'
+                        email = 'team@octopusden.org'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:git://github.com/octopusden/octopus-license-gradle-plugin.git'
+                    developerConnection = 'scm:git:ssh://github.com/octopusden/octopus-license-gradle-plugin.git'
+                    url = 'https://github.com/octopusden/octopus-license-gradle-plugin'
+                }
+            }
         }
     }
 
     repositories {
         mavenLocal()
+    }
+}
+
+signing {
+    def signingKey = project.findProperty('signingKey')
+    def signingPassword = project.findProperty('signingPassword')
+
+    useInMemoryPgpKeys(signingKey, signingPassword)
+
+    gradle.taskGraph.whenReady { taskGraph ->
+        if (taskGraph.hasTask(':publishToSonatype')) {
+            sign publishing.publications.mavenJava
+        }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -90,10 +90,6 @@ publishing {
             }
         }
     }
-
-    repositories {
-        mavenLocal()
-    }
 }
 
 signing {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 //
 plugins {
-    id 'org.octopusden.octopus-release-management'
     id 'groovy'
     id 'java-gradle-plugin'
     id 'io.github.gradle-nexus.publish-plugin'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-release-management.version=2.0.27
+version=1.0-SNAPSHOT
 platformlib-process.version=0.1.4
 gradle-node-plugin.version=3.5.0
 octopus-components-registry-service.version=2.0.27

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,5 @@
 pluginManagement {
     plugins {
-        id 'org.octopusden.octopus-release-management' version '2.0.27'
         id 'io.github.gradle-nexus.publish-plugin' version '1.1.0' apply false
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 pluginManagement {
     plugins {
         id 'org.octopusden.octopus-release-management' version '2.0.27'
+        id 'io.github.gradle-nexus.publish-plugin' version '1.1.0' apply false
     }
 }
 


### PR DESCRIPTION
- Add `io.github.gradle-nexus.publish-plugin` and `signing` plugin to enable `publishToSonatype` task
- Add customize POM for publishing
- Remove `octopus-release-management` plugin