### PR TITLE
Pass Staging Parameter to LicensePluginRunner

### DIFF
--- a/ft/src/main/kotlin/org/octopusden/octopus/license/management/plugins/gradle/license/LicensePluginRunner.kt
+++ b/ft/src/main/kotlin/org/octopusden/octopus/license/management/plugins/gradle/license/LicensePluginRunner.kt
@@ -70,6 +70,7 @@ fun gradleProcessInstance(init: TestGradleDSL.() -> Unit): Pair<ProcessInstance,
         "--info",
         "build",
         "-Plicense-management.version=${licenseManagementVersion}",
+        "-Puse_dev_repository=plugins",
         "-Pmaven-license-parameters=\'${mavenLicenseParameters}\'",
         "-Psupported-groups=${supportedGroups}"
     )

--- a/ft/src/test/resources/projects/LCTRL-110/gradle.properties
+++ b/ft/src/test/resources/projects/LCTRL-110/gradle.properties
@@ -1,1 +1,0 @@
-use_dev_repository=plugins

--- a/ft/src/test/resources/projects/LCTRL-112/gradle.properties
+++ b/ft/src/test/resources/projects/LCTRL-112/gradle.properties
@@ -1,1 +1,0 @@
-use_dev_repository=plugins

--- a/ft/src/test/resources/projects/LCTRL-116/gradle.properties
+++ b/ft/src/test/resources/projects/LCTRL-116/gradle.properties
@@ -1,1 +1,0 @@
-use_dev_repository=plugins

--- a/ft/src/test/resources/projects/LCTRL-122/gradle.properties
+++ b/ft/src/test/resources/projects/LCTRL-122/gradle.properties
@@ -1,1 +1,0 @@
-use_dev_repository=plugins

--- a/ft/src/test/resources/projects/LCTRL-136/gradle.properties
+++ b/ft/src/test/resources/projects/LCTRL-136/gradle.properties
@@ -1,1 +1,0 @@
-use_dev_repository=plugins

--- a/ft/src/test/resources/projects/dependency-substitution/gradle.properties
+++ b/ft/src/test/resources/projects/dependency-substitution/gradle.properties
@@ -1,1 +1,0 @@
-use_dev_repository=plugins

--- a/ft/src/test/resources/projects/ibm-libraries/gradle.properties
+++ b/ft/src/test/resources/projects/ibm-libraries/gradle.properties
@@ -1,1 +1,0 @@
-use_dev_repository=plugins

--- a/ft/src/test/resources/projects/include-pattern/gradle.properties
+++ b/ft/src/test/resources/projects/include-pattern/gradle.properties
@@ -1,1 +1,0 @@
-use_dev_repository=plugins

--- a/ft/src/test/resources/projects/multi-module/gradle.properties
+++ b/ft/src/test/resources/projects/multi-module/gradle.properties
@@ -1,1 +1,0 @@
-use_dev_repository=plugins

--- a/ft/src/test/resources/projects/node-java/gradle.properties
+++ b/ft/src/test/resources/projects/node-java/gradle.properties
@@ -1,1 +1,0 @@
-use_dev_repository=plugins

--- a/ft/src/test/resources/projects/node-multi-module/gradle.properties
+++ b/ft/src/test/resources/projects/node-multi-module/gradle.properties
@@ -1,1 +1,0 @@
-use_dev_repository=plugins

--- a/ft/src/test/resources/projects/node-single-module/gradle.properties
+++ b/ft/src/test/resources/projects/node-single-module/gradle.properties
@@ -1,1 +1,0 @@
-use_dev_repository=plugins

--- a/ft/src/test/resources/projects/octopus-dependencies/gradle.properties
+++ b/ft/src/test/resources/projects/octopus-dependencies/gradle.properties
@@ -1,1 +1,0 @@
-use_dev_repository=plugins

--- a/ft/src/test/resources/projects/single-module/gradle.properties
+++ b/ft/src/test/resources/projects/single-module/gradle.properties
@@ -1,1 +1,0 @@
-use_dev_repository=plugins

--- a/ft/src/test/resources/projects/transitive-conf-false/gradle.properties
+++ b/ft/src/test/resources/projects/transitive-conf-false/gradle.properties
@@ -1,1 +1,0 @@
-use_dev_repository=plugins

--- a/ft/src/test/resources/projects/transitive-dep-false/gradle.properties
+++ b/ft/src/test/resources/projects/transitive-dep-false/gradle.properties
@@ -1,1 +1,0 @@
-use_dev_repository=plugins

--- a/ft/src/test/resources/projects/transitive-false/gradle.properties
+++ b/ft/src/test/resources/projects/transitive-false/gradle.properties
@@ -1,1 +1,0 @@
-use_dev_repository=plugins

--- a/ft/src/test/resources/projects/zip-with-dependencies/gradle.properties
+++ b/ft/src/test/resources/projects/zip-with-dependencies/gradle.properties
@@ -1,2 +1,1 @@
 release-management.version=2.0.27
-use_dev_repository=plugins


### PR DESCRIPTION
- Pass the `use_dev_repository=plugins` to the `LicensePluginRunner`
- Remove the `use_dev_repository=plugins` parameter declaration from `gradle.properties` in `ft` projects