### PR TITLE
Fix default behavior of license.skip and node.skip parameters

### DIFF
--- a/src/main/java/org/octopusden/octopus/license/management/plugins/gradle/utils/MavenParametersUtils.java
+++ b/src/main/java/org/octopusden/octopus/license/management/plugins/gradle/utils/MavenParametersUtils.java
@@ -30,7 +30,7 @@ public final class MavenParametersUtils {
      *
      * @param project the project containing the property
      * @param property the name of the property to check
-     * @return {@code true} if the property value is {@code false}, {@code null}, {@code "false"}, or {@code "null"};
+     * @return {@code true} if the property value is {@code false} or {@code "false"};
      *         {@code false} otherwise
      */
     public static Boolean propertyIsFalse(Project project, String property) {
@@ -40,6 +40,6 @@ public final class MavenParametersUtils {
             propertyValue = String.valueOf(project.getRootProject().findProperty(property));
         }
 
-        return propertyValue == null || propertyValue.equalsIgnoreCase("false") || propertyValue.equalsIgnoreCase("null");
+        return propertyValue.equalsIgnoreCase("false");
     }
 }

--- a/src/test/java/org/octopusden/octopus/license/management/plugins/gradle/MavenParametersUtilsTest.java
+++ b/src/test/java/org/octopusden/octopus/license/management/plugins/gradle/MavenParametersUtilsTest.java
@@ -70,21 +70,18 @@ public class MavenParametersUtilsTest {
 
     /**
      * Tests that {@code propertyIsFalse()} returns {@code true} for properties
-     * with values {@code false}, {@code null}, {@code "false"}, {@code "null"} in
+     * with values {@code false}, {@code "false"} in
      * {@code maven-license-parameters} or project properties.
      */
     @Test
-    void testPropertyIsFalseForFalseOrNullValues() {
+    void testPropertyIsFalseForFalseValue() {
         try (MockedStatic<MavenParametersUtils> mockedStatic = mockStatic(MavenParametersUtils.class)) {
             when(mockProject.findProperty("falseProp")).thenReturn(false);
-            when(mockProject.findProperty("nullProp")).thenReturn(null);
 
             mockedStatic.when(() -> getLicenseParametersProperty(mockProject, "falseStringProp"))
                     .thenReturn("false");
-            mockedStatic.when(() -> getLicenseParametersProperty(mockProject, "nullStringProp"))
-                    .thenReturn("null");
 
-            String[] properties = {"falseProp", "newProp", "falseStringProp", "nullStringProp"};
+            String[] properties = {"falseProp", "falseStringProp"};
             mockPropertyIsFalseToCallRealMethod(mockedStatic, properties);
             for (String property: properties) assertTrue(propertyIsFalse(mockProject, property));
         }
@@ -92,16 +89,19 @@ public class MavenParametersUtilsTest {
 
     /**
      * Tests that {@code propertyIsFalse()} returns {@code false} for properties
-     * with values other than {@code false}, {@code null}, {@code "false"}, {@code "null"} in
+     * with values other than {@code false}, {@code "false"} in
      * {@code maven-license-parameters} or project properties.
      */
     @Test
     void testPropertyIsFalseForNonFalseValues() {
         try (MockedStatic<MavenParametersUtils> mockedStatic = mockStatic(MavenParametersUtils.class)) {
             when(mockProject.findProperty("trueProp")).thenReturn(true);
+            when(mockProject.findProperty("nullProp")).thenReturn(null);
 
             mockedStatic.when(() -> getLicenseParametersProperty(mockProject, "trueStringProp"))
                     .thenReturn("true");
+            mockedStatic.when(() -> getLicenseParametersProperty(mockProject, "nullStringProp"))
+                    .thenReturn("null");
             mockedStatic.when(() -> getLicenseParametersProperty(mockProject, "emptyStringProp"))
                     .thenReturn("");
             mockedStatic.when(() -> getLicenseParametersProperty(mockProject, "whitespaceStringProp"))
@@ -109,7 +109,7 @@ public class MavenParametersUtilsTest {
             mockedStatic.when(() -> getLicenseParametersProperty(mockProject, "randomStringProp"))
                     .thenReturn("random");
 
-            String[] properties = {"trueStringProp", "emptyStringProp", "whitespaceStringProp", "randomStringProp"};
+            String[] properties = {"trueProp", "nullProp", "trueStringProp", "nullStringProp", "emptyStringProp", "whitespaceStringProp", "randomStringProp"};
             mockPropertyIsFalseToCallRealMethod(mockedStatic, properties);
             for (String property: properties) assertFalse(propertyIsFalse(mockProject, property));
         }
@@ -135,7 +135,7 @@ public class MavenParametersUtilsTest {
 
             when(mockProject.findProperty("falseStringProp")).thenReturn(true);
             when(mockProject.findProperty("trueStringProp")).thenReturn(false);
-            when(mockProject.findProperty("nullStringProp")).thenReturn(true);
+            when(mockProject.findProperty("nullStringProp")).thenReturn(false);
             when(mockProject.findProperty("emptyStringProp")).thenReturn(false);
             when(mockProject.findProperty("randomStringProp")).thenReturn(false);
 
@@ -143,7 +143,7 @@ public class MavenParametersUtilsTest {
             mockPropertyIsFalseToCallRealMethod(mockedStatic, properties);
             assertTrue(propertyIsFalse(mockProject, "falseStringProp"));
             assertFalse(propertyIsFalse(mockProject, "trueStringProp"));
-            assertTrue(propertyIsFalse(mockProject, "nullStringProp"));
+            assertFalse(propertyIsFalse(mockProject, "nullStringProp"));
             assertFalse(propertyIsFalse(mockProject, "emptyStringProp"));
             assertFalse(propertyIsFalse(mockProject, "randomStringProp"));
         }


### PR DESCRIPTION
Previously, the `license.skip` parameter defaulted to `false` if it was not explicitly defined in the project. This behavior required developers to either declare additional license-related parameters or explicitly set `license.skip` to `true` to bypass them.

The behavior stemmed from the `propertyIsFalse` function, which treated `null` values as `false` based on the following logic:
```
return propertyValue == null || propertyValue.equalsIgnoreCase("false") || propertyValue.equalsIgnoreCase("null");
```
To resolve this, the logic has been updated so that a `null` value for `license.skip` is now interpreted as `true` instead of `false`.

Note: The `propertyIsFalse` function is only used for validating the `license.skip` and `node.skip` parameters.

Related issue: https://github.com/octopusden/octopus-license-gradle-plugin/issues/16