### PR TITLE
Add condition for processLicensedDependencies task

### DIFF
--- a/src/main/groovy/org/octopusden/octopus/license/management/plugins/gradle/LicenseGradlePlugin.groovy
+++ b/src/main/groovy/org/octopusden/octopus/license/management/plugins/gradle/LicenseGradlePlugin.groovy
@@ -116,9 +116,9 @@ class LicenseGradlePlugin implements Plugin<Project> {
             onlyCurrentProject = onlyCurrent
         }
         Task processLicenses = project.getTasks().create(processLicensesTaskName, LicenseTask.class)
-        def isLicenseSkipFalse = propertyIsFalse(project, LICENSE_SKIP_PROPERTY)
-        processLicensedDependencies.onlyIf { return isLicenseSkipFalse }
+        def isLicenseCheckRequired = propertyIsFalse(project, LICENSE_SKIP_PROPERTY)
+        processLicensedDependencies.onlyIf { return isLicenseCheckRequired }
         processLicenses.dependsOn(processLicensedDependencies)
-        processLicenses.onlyIf { return isLicenseSkipFalse }
+        processLicenses.onlyIf { return isLicenseCheckRequired }
     }
 }

--- a/src/main/groovy/org/octopusden/octopus/license/management/plugins/gradle/LicenseGradlePlugin.groovy
+++ b/src/main/groovy/org/octopusden/octopus/license/management/plugins/gradle/LicenseGradlePlugin.groovy
@@ -116,7 +116,9 @@ class LicenseGradlePlugin implements Plugin<Project> {
             onlyCurrentProject = onlyCurrent
         }
         Task processLicenses = project.getTasks().create(processLicensesTaskName, LicenseTask.class)
+        def isLicenseSkipFalse = propertyIsFalse(project, LICENSE_SKIP_PROPERTY)
+        processLicensedDependencies.onlyIf { return isLicenseSkipFalse }
         processLicenses.dependsOn(processLicensedDependencies)
-        processLicenses.onlyIf { return propertyIsFalse(project, LICENSE_SKIP_PROPERTY) }
+        processLicenses.onlyIf { return isLicenseSkipFalse }
     }
 }


### PR DESCRIPTION
Ensure `processLicensedDependencies` is not executed if the license check is skipped. This task depends on license parameters that developers must specify (components registry URL or list of supported groups), so it should be disabled alongside the license check to prevent unnecessary execution.

Related issue: https://github.com/octopusden/octopus-license-gradle-plugin/issues/16