### PR TITLE
added init.gradle for exclusion of NPM tests

### DIFF
--- a/ft/exclude-tests.gradle
+++ b/ft/exclude-tests.gradle
@@ -1,6 +1,7 @@
 allprojects {
     tasks.withType(Test).configureEach {
         filter {
+            // TODO: this is a workaround for unstable NodeJS-based tests
             excludeTestsMatching "org.octopusden.octopus.license.management.plugins.gradle.license.LicensePluginTest.testNode*"
         }
     }

--- a/ft/exclude-tests.gradle
+++ b/ft/exclude-tests.gradle
@@ -1,10 +1,7 @@
 allprojects {
     tasks.withType(Test).configureEach {
         filter {
-            excludeTestsMatching "org.octopusden.octopus.license.management.plugins.gradle.license.LicensePluginTest.testNodeJava"
-            excludeTestsMatching "org.octopusden.octopus.license.management.plugins.gradle.license.LicensePluginTest.testNodeMultiModule"
-            excludeTestsMatching "org.octopusden.octopus.license.management.plugins.gradle.license.LicensePluginTest.testNodeNpmModule"
-            excludeTestsMatching "org.octopusden.octopus.license.management.plugins.gradle.license.LicensePluginTest.testNodeYarnModule"
+            excludeTestsMatching "org.octopusden.octopus.license.management.plugins.gradle.license.LicensePluginTest.testNode*"
         }
     }
 }

--- a/ft/exclude-tests.gradle
+++ b/ft/exclude-tests.gradle
@@ -1,7 +1,7 @@
 allprojects {
     tasks.withType(Test).configureEach {
         filter {
-            // TODO: this is a workaround for unstable NodeJS-based tests
+            // TODO: this is a workaround for unstable NodeJS-based tests (will be solved in https://github.com/octopusden/octopus-license-gradle-plugin/issues/24)
             excludeTestsMatching "org.octopusden.octopus.license.management.plugins.gradle.license.LicensePluginTest.testNode*"
         }
     }

--- a/ft/exclude-tests.gradle
+++ b/ft/exclude-tests.gradle
@@ -1,0 +1,10 @@
+allprojects {
+    tasks.withType(Test).configureEach {
+        filter {
+            excludeTestsMatching "org.octopusden.octopus.license.management.plugins.gradle.license.LicensePluginTest.testNodeJava"
+            excludeTestsMatching "org.octopusden.octopus.license.management.plugins.gradle.license.LicensePluginTest.testNodeMultiModule"
+            excludeTestsMatching "org.octopusden.octopus.license.management.plugins.gradle.license.LicensePluginTest.testNodeNpmModule"
+            excludeTestsMatching "org.octopusden.octopus.license.management.plugins.gradle.license.LicensePluginTest.testNodeYarnModule"
+        }
+    }
+}


### PR DESCRIPTION
If you want to exclude NPM tests on FT then add --init-script exclude-tests.gradle to GRADLE_PARAMETERS of you FT build.
This is the workaround for https://github.com/octopusden/octopus-license-gradle-plugin/issues/24