### PR TITLE
Extend default exclude pattern for configurations

### DIFF
--- a/src/main/groovy/org/octopusden/octopus/license/management/plugins/gradle/tasks/LicensedDependenciesAnalyzingTask.groovy
+++ b/src/main/groovy/org/octopusden/octopus/license/management/plugins/gradle/tasks/LicensedDependenciesAnalyzingTask.groovy
@@ -22,7 +22,7 @@ class LicensedDependenciesAnalyzingTask extends DefaultTask {
 
     public static final String STRICT_RESOLVER = "strictDependencyResolution"
 
-    private static final String DEFAULT_EXCLUDE_PATTERN = "test.*"
+    private static final String DEFAULT_EXCLUDE_PATTERN = "(test|cyclonedx).*"
     private static final String DEFAULT_INCLUDE_PATTERN = ".*"
 
     @Input


### PR DESCRIPTION
Ignore self-referencing configurations created by org.cyclonedx.bom plugin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated dependency analysis configuration to exclude additional configuration types from processing, ensuring cyclonedx-related configurations are properly filtered alongside test configurations during license dependency analysis.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->