### PR TITLE
Fix printFoundProblems not available in resolution error handler

### DIFF
--- a/src/main/groovy/org/octopusden/octopus/license/management/plugins/gradle/tasks/LicensedDependenciesAnalyzingTask.groovy
+++ b/src/main/groovy/org/octopusden/octopus/license/management/plugins/gradle/tasks/LicensedDependenciesAnalyzingTask.groovy
@@ -77,6 +77,7 @@ class LicensedDependenciesAnalyzingTask extends DefaultTask {
         } else {
             projectsToAnalyze.addAll(project.rootProject.allprojects)
         }
+        def self = this
         projectsToAnalyze.forEach { project$ ->
             def configurationsToAnalyze = new ArrayList(project$.configurations)
             configurationsToAnalyze.forEach { Configuration configuration ->
@@ -124,7 +125,7 @@ class LicensedDependenciesAnalyzingTask extends DefaultTask {
                         resProblemsMessages.append "\nThe '${STRICT_RESOLVER}' mode is set to ${strictDR}\n"
 
                         if (strictDR) {
-                            printFoundProblems(resProblemsMessages)
+                            self.printFoundProblems(resProblemsMessages)
                             throw exception
                         } else {
                             try {


### PR DESCRIPTION
Exception: 
```
Execution failed for task ':processLicensedDependencies'. org.gradle.internal.metaobject.AbstractDynamicObject$CustomMessageMissingMethodException: Could not find method printFoundProblems() for arguments [Unable to resolve configuration
  The resulting list of licenses may be incomplete or empty
  Could not resolve all dependencies for configuration .
  A build operation failed.
      null
  null
  
  The 'strictDependencyResolution' mode is set to true
  ] on task ':processLicensedDependencies' of type org.octopusden.octopus.license.management.plugins.gradle.tasks.LicensedDependenciesAnalyzingTask.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved reliability of the dependency/license analysis task so problem reporting works correctly in strict mode, reducing the risk of missed or misrouted diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->