### PR TITLE
ci: adopt quality-gates and move octopus-base to v2.7.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,17 @@
+# PUBLIC — reusable build (compile + unit tests). Runs on push to main, on manual dispatch,
+# and is called by merge-gate.yml on pull requests. Never triggers directly on pull_request.
 name: Gradle Compile & UT
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches: [ main ]
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   run-build-and-deploy:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.1.7
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.3.5
     with:
       flow-type: hybrid
-      java-version: '8'
+      java-version: '11'
+    secrets: inherit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   run-build-and-deploy:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.7.0
     with:
       flow-type: hybrid
       java-version: '11'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   run-build-and-deploy:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.1
     with:
       flow-type: hybrid
       java-version: '11'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   run-build-and-deploy:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.0
     with:
       flow-type: hybrid
       java-version: '11'

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.4.1
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/license-gradle-plugin/_VER_/license-gradle-plugin-_VER_.jar"

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.7.0
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/license-gradle-plugin/_VER_/license-gradle-plugin-_VER_.jar"

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.1.7
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.3.5
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/license-gradle-plugin/_VER_/license-gradle-plugin-_VER_.jar"

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.4.0
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/license-gradle-plugin/_VER_/license-gradle-plugin-_VER_.jar"

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -1,0 +1,32 @@
+# PUBLIC — every PR triggers this workflow; the gate/merge check must be green to merge.
+# Fans out to the local reusable build / quality / security workflows and aggregates their
+# results into a single required status check via the octopus-base merge-gate action.
+name: Merge Gate
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    secrets: inherit
+
+  quality:
+    uses: ./.github/workflows/quality.yml
+    secrets: inherit
+
+  security:
+    uses: ./.github/workflows/security.yml
+    secrets: inherit
+
+  gate-merge:
+    name: gate/merge
+    needs: [ build, quality, security ]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.3.5
+        with:
+          needs: ${{ toJson(needs) }}

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -27,6 +27,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.3.5
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.4.0
         with:
           needs: ${{ toJson(needs) }}

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -27,6 +27,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.4.0
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.4.1
         with:
           needs: ${{ toJson(needs) }}

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -27,6 +27,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.4.1
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.7.0
         with:
           needs: ${{ toJson(needs) }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.4.1
     with:
       java-version: '11'
     secrets: inherit

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.4.0
     with:
       java-version: '11'
     secrets: inherit

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.7.0
     with:
       java-version: '11'
     secrets: inherit

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,17 @@
+# PUBLIC — reusable quality gates (qualityStatic + qualityCoverage). Runs on push to main,
+# on manual dispatch, and is called by merge-gate.yml on pull requests. Never triggers
+# directly on pull_request.
+name: Quality
+
+on:
+  push:
+    branches: [ main ]
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  quality:
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.3.5
+    with:
+      java-version: '11'
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.0
     with:
       flow-type: hybrid
       java-version: '11'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.1
     with:
       flow-type: hybrid
       java-version: '11'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,10 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.1.7
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.3.5
     with:
       flow-type: hybrid
-      java-version: '8'
+      java-version: '11'
       commit-hash: ${{ github.event.client_payload.commit }}
       build-version: ${{ github.event.client_payload.project_version }}
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.7.0
     with:
       flow-type: hybrid
       java-version: '11'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.7.0
     with:
       java-version: '11'
     secrets: inherit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.4.1
     with:
       java-version: '11'
     secrets: inherit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.4.0
     with:
       java-version: '11'
     secrets: inherit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,19 @@
+# PUBLIC — reusable security reports (CodeQL, Trivy). Runs on push to main, weekly, on manual
+# dispatch, and is called by merge-gate.yml on pull requests. Never triggers directly on
+# pull_request.
+name: Security
+
+on:
+  push:
+    branches: [ main ]
+  schedule:
+    - cron: '0 3 * * 1'   # every Monday at 03:00 UTC
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  security:
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.3.5
+    with:
+      java-version: '11'
+    secrets: inherit

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,15 @@ group = 'org.octopusden.octopus'
 description 'Octopus module for license gradle plugin'
 
 octopusQuality {
+    // Regression guard on what reaches Maven Central, from octopus-base v2.7.0.
+    publication {
+        enforceCentralPublications.set(true)
+        centralPublications.set([
+            ':|pluginMaven|org.octopusden.octopus:license-gradle-plugin|[jar, jar:javadoc, jar:sources]',
+            ':|LicenseGradlePluginPluginMarkerMaven|' +
+                'org.octopusden.octopus.license-management:org.octopusden.octopus.license-management.gradle.plugin|[]',
+        ] as Set)
+    }
     // No jacoco/kover in this repo — keep coverage verification disabled.
     coverage {
         enabled.set(false)

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ octopusQuality {
     // failOnViolation is left at the convention default (false) for the Java and
     // Groovy analysers: the convention plugin exposes no baseline mechanism for
     // checkstyle/pmd/spotbugs/codenarc (only detekt/ktlint have baselines), and the
-    // existing code carries pre-existing debt (268 SpotBugs findings, ~11 CodeNarc).
+    // existing code carries pre-existing debt (134 SpotBugs findings, 11 CodeNarc).
     // The gate therefore runs every analyser and publishes reports, but does not
     // fail the build on that legacy debt. Flip these to true once the debt is burned
     // down. Checkstyle and PMD already pass clean.

--- a/build.gradle
+++ b/build.gradle
@@ -5,10 +5,35 @@ plugins {
     id 'io.github.gradle-nexus.publish-plugin'
     id 'signing'
     id 'com.jfrog.artifactory'
+    id 'org.octopusden.octopus-quality'
 }
 
 group = 'org.octopusden.octopus'
 description 'Octopus module for license gradle plugin'
+
+octopusQuality {
+    // No jacoco/kover in this repo — keep coverage verification disabled.
+    coverage {
+        enabled.set(false)
+    }
+    // Main sources are Groovy + Java, so the convention plugin auto-applies
+    // codenarc (Groovy) and checkstyle/pmd/spotbugs (Java). No Kotlin module
+    // exists in this build, so detekt/ktlint are not wired.
+    //
+    // failOnViolation is left at the convention default (false) for the Java and
+    // Groovy analysers: the convention plugin exposes no baseline mechanism for
+    // checkstyle/pmd/spotbugs/codenarc (only detekt/ktlint have baselines), and the
+    // existing code carries pre-existing debt (268 SpotBugs findings, ~11 CodeNarc).
+    // The gate therefore runs every analyser and publishes reports, but does not
+    // fail the build on that legacy debt. Flip these to true once the debt is burned
+    // down. Checkstyle and PMD already pass clean.
+    java {
+        failOnViolation.set(false)
+    }
+    groovy {
+        failOnViolation.set(false)
+    }
+}
 
 repositories {
     mavenCentral()

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ octopus-components-registry-service.version=2.0.27
 junit-jupiter.version=5.10.2
 mockito-core.version=3.12.4
 gradle-nexus.version=1.1.0
-octopus-quality.version=2.4.1
+octopus-quality.version=2.7.0
 
 # Versions 5.x and above are incompatible with the octopus-rm-gradle-plugin/octopus-release-management
 jfrog-artifactory.version=4.33.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,7 @@ octopus-components-registry-service.version=2.0.27
 junit-jupiter.version=5.10.2
 mockito-core.version=3.12.4
 gradle-nexus.version=1.1.0
+octopus-quality.version=2.3.5
 
 # Versions 5.x and above are incompatible with the octopus-rm-gradle-plugin/octopus-release-management
 jfrog-artifactory.version=4.33.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ octopus-components-registry-service.version=2.0.27
 junit-jupiter.version=5.10.2
 mockito-core.version=3.12.4
 gradle-nexus.version=1.1.0
-octopus-quality.version=2.4.0
+octopus-quality.version=2.4.1
 
 # Versions 5.x and above are incompatible with the octopus-rm-gradle-plugin/octopus-release-management
 jfrog-artifactory.version=4.33.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ octopus-components-registry-service.version=2.0.27
 junit-jupiter.version=5.10.2
 mockito-core.version=3.12.4
 gradle-nexus.version=1.1.0
-octopus-quality.version=2.3.5
+octopus-quality.version=2.4.0
 
 # Versions 5.x and above are incompatible with the octopus-rm-gradle-plugin/octopus-release-management
 jfrog-artifactory.version=4.33.1

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,12 @@
 pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
     plugins {
         id 'io.github.gradle-nexus.publish-plugin' version settings['gradle-nexus.version'] apply false
         id 'com.jfrog.artifactory' version settings['jfrog-artifactory.version']
+        id 'org.octopusden.octopus-quality' version settings['octopus-quality.version']
     }
 }
 


### PR DESCRIPTION
> [!WARNING]
> **Do not merge until the TeamCity JDK is raised.** GitHub Actions is green here, but this repository's TeamCity build configuration `[1.0] Compile & UT` launches Gradle on **Java 8** (`JAVA_HOME = %env.JDK_1_8_x64%`), and `octopus-quality-plugin` — which this PR adopts — declares `org.gradle.jvm.version = 11` in its Gradle module metadata. Dependency resolution will fail before compilation:
>
> ```
> VariantSelectionByAttributesException:
> Dependency requires at least JVM runtime version 11. This build uses a Java 8 JVM.
> ```
>
> This is **not fixable from this PR**: there is no `.teamcity/` directory here, so the build configuration lives in the TeamCity UI. Nor is it fixable by choosing a different plugin version — 2.4.1, 2.5.2, 2.6.2 and 2.7.0 all declare 11. `detekt-gradle-plugin` 1.23.8 and `ktlint-cli` 1.5.0 both declare 8, so they are not the cause.
>
> The same blocker already stopped `octopus-build-integration-gradle-plugin` (see that repo's issue #12) and caused `octopus-rm-gradle-plugin` #79 to decline adoption outright.
>
> Green GitHub checks are exactly what makes this dangerous: its runners use a newer JDK, so nothing here surfaces the problem until the first TeamCity run after merge.

## What this PR now covers

Originally opened to adopt the octopusden quality-gates convention (below, unchanged in substance).
Extended in this update to move `octopus-base`/`octopus-quality` the rest of the way to **v2.7.0**
and add the shared Maven Central publication-set guard. Both parts are described here since the
branch now carries both.

## Quality-gates adoption (original scope, as merged into this branch)

- Apply `org.octopusden.octopus-quality`, wiring a mandatory `gate/merge` status check on PRs
  without disturbing the bespoke publish/release flow.
- Main sources are **Groovy + Java**, so the convention auto-applies checkstyle/pmd/spotbugs
  (Java) and codenarc (Groovy). No Kotlin module exists in this build, so detekt/ktlint are not
  wired.
- `java`/`groovy` `failOnViolation` stays at the convention default (`false`): the convention has
  no baseline mechanism for checkstyle/pmd/spotbugs/codenarc (only detekt/ktlint have baselines),
  and the code carries pre-existing debt (134 SpotBugs findings, 11 CodeNarc — both counted from the generated reports, `total_bugs` in `build/reports/spotbugs/main.xml` and `priority3` in the CodeNarc XML). `qualityStatic`
  runs every analyser and publishes reports without failing on the legacy debt; checkstyle and
  PMD already pass clean.
- `merge-gate.yml` fans out to `build`/`quality`/`security` and aggregates them via the
  octopus-base merge-gate action; `release.yml`/`check-and-register.yml` logic is untouched,
  only their pinned refs move.
- JDK bumped 8 → 11 for the build/release runtime (the quality convention plugin ships Java 11
  bytecode); published bytecode target stays 1.8 (`java { targetCompatibility }`), so consumers
  are unaffected.

## This update: move to v2.7.0, add the shared publication guard

**All six workflow refs** (`build.yml`, `check-and-register.yml`, `merge-gate.yml`, `quality.yml`,
`release.yml`, `security.yml`) move from v2.4.1 (this branch's own most recent bump, itself three
tags ahead of `main`'s v2.1.7) to **v2.7.0**. `octopus-quality` was never pinned on `main` at all —
this PR is what establishes it — so it goes straight to **2.7.0** in `gradle.properties`, which
`settings.gradle`'s `pluginManagement` already reads. Whole-tree grep for `2.4.1`/`2.1.7` after the
bump: zero hits, `.yaml` included; this repository has no `.github/actions/` of its own to check
separately.

**Checked for a hand-rolled `verifyCentralPublicationPolicy`, per the concern that a sibling
repository's quality-gates PR had added one even though `main` did not** — this repository's
branch has none (grepped the whole tree for `verifyCentralPublicationPolicy`,
`centralPublishedProjects`, `AbstractPublishToMaven`, `PublishingExtension`: zero hits outside
octopus-quality's own plugin code). So there is nothing to delete here, and this PR does not claim
one — the `octopusQuality { publication { } }` block is a pure addition, with no task-name
collision to resolve.

**The declared set — confirmed from the build, not copied from the brief:**
```groovy
publication {
    enforceCentralPublications.set(true)
    centralPublications.set([
        ':|pluginMaven|org.octopusden.octopus:license-gradle-plugin|[jar, jar:javadoc, jar:sources]',
        ':|LicenseGradlePluginPluginMarkerMaven|' +
            'org.octopusden.octopus.license-management:org.octopusden.octopus.license-management.gradle.plugin|[]',
    ] as Set)
}
```
Derived by declaring an **empty** set and running `verifyCentralPublicationPolicy` directly (an
empty declared set blocks `publishToMavenLocal`, so the usual `--from-gradle` measurement route
does not work here) — the task's own failure message printed the `publishing:` set verbatim, and
it matched exactly. Two things worth stating precisely because they're easy to get wrong by
assumption rather than by reading the build:
- The published **artifactId is `license-gradle-plugin`**, not `octopus-license-gradle-plugin` —
  it comes from `rootProject.name` in `settings.gradle`, not the GitHub repository name.
- The `java-gradle-plugin` marker publication's coordinate is
  `org.octopusden.octopus.license-management:org.octopusden.octopus.license-management.gradle.plugin`
  — a **dot**, not a hyphen, and a name (`license-management`) that matches neither the repository
  name nor the main artifactId. Read directly from this build's own
  `gradlePlugin.plugins.LicenseGradlePlugin.id`, not assumed from the repo name.
- `[] as Set` / `[...] as Set` throughout, not a bare list literal — in Groovy a `Set` is never
  equal to a `List` even with identical elements, so a plain-list declaration would fail the guard
  on every publish.

## Verification (all `--no-daemon`)

- **GREEN**, declared set matching the build: `./gradlew verifyCentralPublicationPolicy` →
  `BUILD SUCCESSFUL`.
- **RED, signature axis**: dropped `jar:sources` from `pluginMaven`'s signature only → `BUILD
  FAILED` with the correct declared-vs-publishing diff.
- **RED, marker axis** (the likelier real omission, since the marker publication is generated
  automatically by `java-gradle-plugin` and easy to forget): removed the marker entry from the
  declared set entirely → `BUILD FAILED`, `publishing:` still lists the marker, `declared:` does
  not.
- Restored the correct two-entry set → `BUILD SUCCESSFUL` again, confirming the task is not red
  (or green) unconditionally in either state.
- `./gradlew check --dry-run` schedules `verifyCentralPublicationPolicy` exactly once.
- `./gradlew checkstyleMain checkstyleTest pmdMain pmdTest codenarcMain codenarcTest spotbugsMain
  spotbugsTest` — `BUILD SUCCESSFUL` (CodeNarc/SpotBugs report the same pre-existing debt counts
  as before this change; `failOnViolation` stays `false` for those, as already documented above).
- `./gradlew build -x test` — `BUILD SUCCESSFUL`, 20 tasks; `validatePublications` reports
  "2 publication(s) in : passed Maven Central checks", and `verifyCentralPublicationPolicy` runs
  as part of `check`.
- `./gradlew test` (and hence unqualified `build`) **fails — 9 tests, all in
  `MavenParametersUtilsTest`, all the same underlying cause**:
  `MockitoException: Mockito cannot mock this class: interface org.gradle.api.Project` (ByteBuddy
  inline-mock instrumentation failing under JDK 21 against `mockito-core 3.12.4`, pinned in
  `gradle.properties` and unrelated to this PR). **Confirmed pre-existing, not introduced by this
  change**: `git stash`ed this PR's diff, reran `./gradlew test` against the branch's prior tip
  (`1b6e2f9`, before this update) — identical 9/9 failure, same stack trace. Restored the diff
  afterward.

## Not verified locally

- This repository is `flow-type: hybrid`, so a TeamCity build drives releases; that build was not
  checked (no `.teamcity/` config is versioned in this repo — the config lives in the TC UI — and
  TC access/credentials were not exercised for this PR).
- The actual GitHub Actions run of the bumped workflows against octopus-base v2.7.0.
- `dockerPushImage`/publish-to-Sonatype/Artifactory paths — this repository publishes to both
  Sonatype (`nexusPublishing`) and an internal Artifactory (`com.jfrog.artifactory`); neither was
  exercised, since doing so requires real credentials this environment does not have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build & Quality**
  - Upgraded automated build, release, quality, and security checks to Java 11.
  - Added centralized quality analysis and reporting.
  - Quality checks now report violations without blocking builds.

- **CI/CD**
  - Added automated merge gating for the main branch.
  - Added scheduled and manually triggered security checks.
  - Improved workflow support for reusable and manually dispatched runs.

- **Publishing**
  - Configured approved artifacts for Central publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->